### PR TITLE
implement the code for the issue #3 and its associated document

### DIFF
--- a/bin/gce-create-instance
+++ b/bin/gce-create-instance
@@ -3,11 +3,12 @@
 SCOPES=${SCOPES:-storage-ro}
 
 instname=$1
+bucketname=$2
 if [ -z "$instname" ]; then
-  echo "Usage: `basename $0` <instance_name> [machine_type]"
+  echo "Usage: `basename $0` <instance_name> <bucket_name> [machine_type]"
   exit
 fi
-machtype=${2:-n1-standard-1}
+machtype=${3:-n1-standard-1}
 
 startup=$(mktemp -t gcp.startup.XXXXXXXXXX.sh) || exit
 cat << EOF >> $startup
@@ -17,7 +18,7 @@ timedatectl set-timezone Asia/Taipei
 apt-get install -y git build-essential liblapack-pic liblapack-dev
 # downloadload conda packages.
 mkdir -p /var/lib/conda/packages
-gsutil -m rsync -d -r gs://conda-packages/ /var/lib/conda/packages/
+gsutil -m rsync -d -r $bucketname /var/lib/conda/packages/
 # prepare gce bootstrap. (make it the last step!)
 wget -q https://raw.githubusercontent.com/solvcon/solvcon-gce/master/bin/admin/bootstrap-gce.sh
 chmod a+rx bootstrap-gce.sh

--- a/etc/gcerc
+++ b/etc/gcerc
@@ -52,9 +52,10 @@ gscp() {
 
 gstart() {
   instname=$1
-  noinst=$2
+  bucketname=$2
+  noinst=$3
   if [ -z "$noinst" ]; then
-    gce-create-instance $instname
+    gce-create-instance $instname $bucketname
   fi
   gce-register-instance $instname
   cmd="while [ ! -f /var/lib/bootstrap-gce.sh ] ; \


### PR DESCRIPTION
I add an option for gstart so we could now use the command as

```
gstart solvcon-instance gs://conda-packages-mine/
```

Besides, I update its associated document. Please note I have switched the order between **Use an Instance** and **Cache Conda Packages**, because it is necessary to build the cache first for now.
