### PR TITLE
always expand aliases

### DIFF
--- a/etc/gcerc
+++ b/etc/gcerc
@@ -85,6 +85,11 @@ alias gcescp="scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 # conda.
 alias use.conda3="namemunge PATH ~/opt/conda3/bin"
 alias use.conda2="namemunge PATH ~/opt/conda2/bin"
-if [ -d ~/opt/conda3/bin ]; then use.conda3; fi
+# aliases are not expanded when the shell is not interactive.  This cause error
+# message "use.conda3: command not found" dumped to stdout, and may result in
+# the other issues. For example, when non-interactive ssh connection is
+# established to scale up parallel computing, the shell may access the message
+# from the stdout.  Use explicit commands instead of aliases.
+if [ -d ~/opt/conda3/bin ]; then namemunge PATH ~/opt/conda3/bin; fi
 
 # vim: set et nobomb fenc=utf8 ft=sh ff=unix sw=2 ts=2:


### PR DESCRIPTION
aliases are not expanded when the shell is not interactive.  This cause error message "use.conda3: command not found" dumped to stdout, and may result in the other issues. For example, when non-interactive ssh connection is established to scale up parallel computing, the shell may access the message from the stdout.  Use shopt to always enable aliases expanded.

Test case:
A ftest case of SOLVCON https://github.com/solvcon/solvcon

```
nosetests test_rpc.py
```

Please refer to the aliases manual as well:
https://www.gnu.org/software/bash/manual/html_node/Aliases.html
**Aliases are not expanded when the shell is not interactive, unless the expand_aliases shell option is set using shopt (see The Shopt Builtin).**

Another way to fix this issue is to use absolute path instead of aliases. You may be interested in this discussion thread:
http://unix.stackexchange.com/questions/1496/why-doesnt-my-bash-script-recognize-aliases
