### PR TITLE
Mute the prompt when deleting instances.

### DIFF
--- a/bin/gce-delete-instance
+++ b/bin/gce-delete-instance
@@ -1,12 +1,40 @@
 #!/bin/bash
 
+uage="Usage: `basename $0` <instance_name> [-q | --quite]"
+
 instname=$1
 if [ -z "$instname" ]; then
-  echo "Usage: `basename $0` <instance_name>"
+  echo $usage
   exit
 fi
 
-gcloud compute instances delete $instname
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+cmd="gcloud compute instances delete $instname"
+
+case $key in
+  -q|--quite)
+  cmd="$cmd -q"
+  shift
+  ;;
+  -h|--help)
+  help="1"
+  ;;
+  *)
+    # unknown option
+  ;;
+esac
+shift # past argument or value
+done
+
+if [ -n "$help" ]; then
+  echo $usage
+  exit
+fi
+
+$cmd
 instdir=$SCGCE/var/run/$instname
 if [ -d $instdir ]; then rm -rf $instdir; fi
 


### PR DESCRIPTION
Add a option to mute the prompt when deleting instances. By default the
prompt to ask if to delete the instance is "yes." This option could use
the default answer to bypass the prompt, so we could issue commands in
a much more flexible way.

**Test Case**

```
gce-delete-instance <instance> -q
```

and

```
gce-delete-instance <instance> --quite
```

These two commands are equally.

**Expected result**

Without appending the option, there would be a prompt like this:

```
The following instances will be deleted. Attached disks configured to 
be auto-deleted will be deleted unless they are attached to any other 
instances. Deleting a disk is irreversible and any data on the disk 
will be lost.
 - [cluster-node-01] in [asia-east1-c]

Do you want to continue (Y/n)?
```

With the option `-q` and `--quite`, this prompt should be gone. Only this kind of message will be shown on stdin:

```
Deleted [https://www.googleapis.com/compute/v1/projects/solvcon-1369/zones/asia-east1-c/instances/cluster-master].
```
