### PR TITLE
Ref issue 10 wrapper to build a SOLVCON cluster.

### DIFF
--- a/bin/gce-guess-master
+++ b/bin/gce-guess-master
@@ -1,0 +1,18 @@
+#!/bin/bash
+# guess master node and try to return its IP address.
+
+guess_candidates=`gcloud --format="table[no-heading](networkInterfaces[0].networkIP, name)" compute instances list | grep master`
+guess_candidates_nf=`echo $guess_candidates | awk {'print NF'}`
+
+# NF is 2 because it is ip-hostname pair.
+if [ ! $guess_candidates_nf -eq 2 ]; then
+  echo "Can not guess which instance is the master node successfully. Possible candidates:"
+  echo $guess_candidates
+  exit
+fi
+
+guess_ip=`echo $guess_candidates | awk {'print $1'}`
+
+echo $guess_ip
+
+# vim: set et nobomb fenc=utf8 ft=sh ff=unix sw=2 ts=2:

--- a/etc/gcerc
+++ b/etc/gcerc
@@ -124,6 +124,152 @@ echo \"run /var/lib/bootstrap-gce.sh\" ; \
   gssh $instname $cmd
 }
 
+gmaster() {
+  # build a master node of SOLVCON cluster.
+
+  usage="Usage: gmaster <instance_name>"
+
+  instname=$1
+  shift
+  if [ -z "$instname" ]; then
+    echo "Incorrect instance name"
+    echo $usage
+    return
+  fi
+
+  while [[ $# -gt 0 ]]
+  do
+  key="$1"
+
+  case $key in
+    -h|--help)
+    help="1"
+    ;;
+    *)
+      # unknown option
+    ;;
+  esac
+  shift # past argument or value
+  done
+
+  if [ -n "$help" ]; then
+    echo $usage
+    return
+  fi
+
+  script_location="$HOME/opt/gce/bin/admin/bootstrap-cluster.sh"
+  cmd="echo \"run $script_location master\" ; \
+$script_location master"
+  gssh $instname $cmd
+}
+
+gclient() {
+  # build a client node of SOLVCON cluster.
+
+  usage="Usage: gclient <instance_name> [-i master node IP]"
+
+  instname=$1
+  shift
+  if [ -z "$instname" ]; then
+    echo "Incorrect instance name"
+    echo $usage
+    return
+  fi
+
+  while [[ $# -gt 0 ]]
+  do
+  key="$1"
+
+  case $key in
+    -i|--ip-address)
+    ip_address="$2"
+    shift
+    ;;
+    -h|--help)
+    help="1"
+    ;;
+    *)
+      # unknown option
+    ;;
+  esac
+  shift # past argument or value
+  done
+
+  if [ -n "$help" ]; then
+    echo $usage
+    return
+  fi
+
+  script_location="$HOME/opt/gce/bin/admin/bootstrap-cluster.sh"
+  ip_address=`gce-guess-master`
+  script_cmd="$script_location client -i $ip_address"
+  cmd="echo \"run $script_cmd\" ; \
+$script_cmd"
+  gssh $instname $cmd
+}
+
+gcluster() {
+  # build a SOLVCON cluster with GCE.
+  # instance number should be larger than 1, because there should be 1 node used
+  # as a master and the others are client nodes. The master node is bulit by
+  # default.
+  usage="Usage: gcluster <instance_number>"
+
+  instnumber=$1
+  shift
+  if [ "$instnumber" -lt 1 ]; then
+    echo "Incorrect instance number."
+    echo $usage
+    return
+  fi
+
+  while [[ $# -gt 0 ]]
+  do
+  key="$1"
+
+  case $key in
+    -n|--nosetests)
+    # build and run nosetests right after the cluster is ready.
+    nose="1"
+    ;;
+    -h|--help)
+    help="1"
+    ;;
+    *)
+      # unknown option
+    ;;
+  esac
+  shift # past argument or value
+  done
+
+  if [ -n "$help" ]; then
+    echo $usage
+    return
+  fi
+
+  echo "Building master node ..."
+  # Do not use underscore for instance naming. GCE kits do not allow underscore
+  # for field conflict.
+  gstart "solvcon-cluster-master"
+  gmaster "solvcon-cluster-master"
+  for (( node_index=1; node_index<=$instnumber; node_index++ ))
+  #for node_index in {1..$instnumber};
+  do
+    echo "Building client node $node_index ..."
+    gstart "solvcon-cluster-client-$node_index"
+    gclient "solvcon-cluster-client-$node_index"
+  done
+  echo "Complete to build a SOLVCON cluster!"
+  if [ -n "$nose"]; then
+    cmd="source activate ; \
+    export SOLVCON_NODELIST=$HOME/solvcon-remote/node_list ; \
+    cd $HOME/solvcon-remote/solvcon-src ; \
+    python setup.py build_ext --inplace; \
+    nosetests ftests/parallel/test_remote.py"
+    gssh solvcon-cluster-client-1 $cmd
+  fi
+}
+
 alias gcessh="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 alias gcescp="scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 


### PR DESCRIPTION
This is the prototype of the project 1 https://github.com/solvcon/solvcon-gce/projects/1 . This commit has many hard-coded lines and bad argument design. However it works, so I think it would be good to create a PR for the team to have a discussion thread. Comments are very welcome and appreciated, so I could improve this wrapper.

This wrapper is very implemented with straightforward shell scripts. No more HPC or Cloud manager is used. We are surveying such tools to enhance SOLVCON-GCE.

**Test Case**
1. Fetch the branch. Tweak the test configuration like this commit https://github.com/tai271828/solvcon-gce/commit/2c4fc9e7c4f225b26ffe1acf4c609c2488da9cb2
2. Source your gce. Issue the command `gcluster 2 -n` to build the cluster which has 1 master node and 2 client nodes.

**Expected Result**
3 GCE instances should be built. They are 1 master node and 2 client nodes respectively. SOLVCON unit test `test_remote.py` should be launched automatically and pass like this:

```
S..S
----------------------------------------------------------------------
Ran 4 tests in 11.872s

OK (SKIP=2)
```

`gcelist` should give there 3 instances:

```
NAME                      ZONE          MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP      STATUS
solvcon-cluster-client-1  asia-east1-c  n1-standard-1               10.140.0.3   104.199.169.104  RUNNING
solvcon-cluster-client-2  asia-east1-c  n1-standard-1               10.140.0.4   104.199.223.193  RUNNING
solvcon-cluster-master    asia-east1-c  n1-standard-1               10.140.0.2   104.155.228.56   RUNNING

```

The two test have been run are test cases `test_dsoln` and `test_dsoln_cluster`. You could also issue `gssh  solvcon-cluster-client-1` to login the instance, `export SOLVCON_NODELIST=~/solvcon-remote/node_list`, and then `nosetests ftests/parallel/test_remote.py -v` to confirm those two test cases were run.
