### PR TITLE
Add a command to batch destroy instances.

### DIFF
--- a/bin/gce-delete-instance
+++ b/bin/gce-delete-instance
@@ -1,29 +1,26 @@
 #!/bin/bash
 
-uage="Usage: `basename $0` <instance_name> [-q | --quite]"
-
-instname=$1
-if [ -z "$instname" ]; then
-  echo $usage
-  exit
-fi
+usage="Usage: `basename $0` [instance1 [instance2 [...]]] [-a | --all] [-q | --quiet] [-h | --help]"
 
 while [[ $# -gt 0 ]]
 do
 key="$1"
 
-cmd="gcloud compute instances delete $instname"
-
 case $key in
-  -q|--quite)
-  cmd="$cmd -q"
-  shift
+  -a|--all)
+  # delete all instances by default
+  instances_to_destroy=`gcloud --format="table[no-heading](name)" compute instances list`
+  ;;
+  -q|--quiet)
+  quiet="-q"
   ;;
   -h|--help)
   help="1"
   ;;
   *)
-    # unknown option
+  # Unknown option, treat it as a instance name.
+  # Append it into the instance list to be destroyed.
+  instances_to_destroy="$instances_to_destroy $key"
   ;;
 esac
 shift # past argument or value
@@ -34,8 +31,18 @@ if [ -n "$help" ]; then
   exit
 fi
 
-$cmd
-instdir=$SCGCE/var/run/$instname
-if [ -d $instdir ]; then rm -rf $instdir; fi
+if [ -z "$instances_to_destroy" ]; then
+  echo "No instance is given."
+  exit
+fi
+
+for instance in $instances_to_destroy
+do
+  echo "Destorying instance: $instance"
+  cmd="gcloud compute instances delete $instance $quiet"
+  $cmd
+  instdir=$SCGCE/var/run/$instance
+  if [ -d $instdir ]; then rm -rf $instdir; fi
+done
 
 # vim: set et nobomb fenc=utf8 ft=sh ff=unix sw=2 ts=2:


### PR DESCRIPTION
The current command gce-delete-instance could only delete one instance
at a time. This command uses gce-delete-instance in a for loop to
batch destroy instances. This command is useful when creating a test
cluster which will be destoried very soon to avoid costly GCE bill.

**Test Case**
1. Create several instances. `gstart instance01; gstart instance02; gstart instance03; gstart instance04; gstart instance05; gstart instance06`
2. `gce-delete-instance`[1]
3. `gce-delete-instance instance01`[2]
4. `gce-delete-instance instance01 -q`[3]
5. `gce-delete-instance -a`[4]
6. `gce-delete-instance -a -q`[5]

**Expected Result**

[1] This command should does nothing but complain `No instance is given.`
[2] This command should prompt to delete `instance01`
[3] This command should delete `instance01` without prompt.
[4] This command should try to delete all instances with prompt.
[5] This command should try to delete all instances without prompt.
